### PR TITLE
fix: fallback to tabs.create when openOptionsPage fails

### DIFF
--- a/shinkansen/popup/popup.js
+++ b/shinkansen/popup/popup.js
@@ -352,8 +352,14 @@ $('bilingual-toggle').addEventListener('change', async (e) => {
   }
 });
 
-$('options-btn').addEventListener('click', () => {
-  browser.runtime.openOptionsPage();
+$('options-btn').addEventListener('click', async() => {
+  try{
+    await browser.runtime.openOptionsPage();
+  } catch (e) {
+    // 如果 openOptionsPage 不支援（例如 Arc），退而求其次直接開啟 options.html 頁面
+    const url = browser.runtime.getURL('options/options.html');
+    await browser.tabs.create({ url });
+  }
 });
 
 // v1.6.23:popup 開著時 reactive sync ytSubtitle.autoTranslate(設定頁同步寫 storage 後立即反映)


### PR DESCRIPTION
browser.runtime.openOptionsPage() may fail silently in some browsers (e.g. Arc). Fall back to browser.tabs.create() with the extension's options URL as a cross-browser workaround.