### PR TITLE
fix: 部分模型序號標記變形（«1» → N1）導致譯文殘留 N1/N2

### DIFF
--- a/shinkansen/lib/gemini.js
+++ b/shinkansen/lib/gemini.js
@@ -504,8 +504,8 @@ async function translateChunk(texts, settings, glossary, fixedGlossary, forbidde
     outputPreview: text.slice(0, 300),
   });
 
-  // v0.89: split 後移除序號標記 «N»（若有）
-  const SEQ_MARKER_RE = /^«\d+»\s*/;
+  // split 後移除序號標記 «N»；多段時額外處理本地模型把 «1» 變形為 N1 的情況
+  const SEQ_MARKER_RE = texts.length > 1 ? /^(?:«\d+»|N\d+)\s*/ : /^«\d+»\s*/;
   const parts = text.split(DELIMITER).map(s => s.trim().replace(SEQ_MARKER_RE, ''));
   // 若回傳段數不符，且本批不只一段，則 fallback 改為逐段單獨翻譯，確保對齊
   if (parts.length !== texts.length) {
@@ -607,7 +607,7 @@ export async function translateBatchStream(texts, settings, glossary, fixedGloss
   });
 
   const t0 = Date.now();
-  const SEQ_MARKER_RE = /^«\d+»\s*/;
+  const SEQ_MARKER_RE = texts.length > 1 ? /^(?:«\d+»|N\d+)\s*/ : /^«\d+»\s*/;
 
   let resp;
   try {

--- a/shinkansen/lib/openai-compat.js
+++ b/shinkansen/lib/openai-compat.js
@@ -250,7 +250,8 @@ async function translateChunk(texts, settings, glossary, fixedGlossary, forbidde
   });
 
   // 拆分對齊（與 Gemini 同邏輯：split by DELIMITER + 移除 «N» 序號標記）
-  const SEQ_MARKER_RE = /^«\d+»\s*/;
+  // 多段時額外處理本地模型把 «1» 變形為 N1 的情況
+  const SEQ_MARKER_RE = texts.length > 1 ? /^(?:«\d+»|N\d+)\s*/ : /^«\d+»\s*/;
   const parts = text.split(DELIMITER).map(s => s.trim().replace(SEQ_MARKER_RE, ''));
   if (parts.length !== texts.length) {
     await debugLog('warn', 'api', 'openai-compat segment count mismatch — fallback to per-segment', {


### PR DESCRIPTION
## Summary
- 部分模型（如 gemma-4-e2b-it）會把批次翻譯的 `«1»`/`«2»` 序號標記變形為 `N1`/`N2`，殘留在譯文中
- 擴展 `SEQ_MARKER_RE` 在多段模式下額外匹配 `N\d+` 變體
- 單段模式維持原 regex，避免誤刪 `N95` 等合法內容

## Changed files
- `shinkansen/lib/gemini.js` — non-streaming + streaming 兩處 SEQ_MARKER_RE
- `shinkansen/lib/openai-compat.js` — OpenAI-compatible 路徑 SEQ_MARKER_RE

## Test plan
- [ ] 用部分模型（mlx gemma-4-e2b-it）翻譯 YouTube 字幕，確認 N1/N2 不再殘留
- [ ] 用 Gemini API 翻譯一般網頁，確認原行為不受影響
- [ ] 翻譯含 N95、N64 等內容的頁面，確認不被誤刪

🤖 Generated with [Claude Code](https://claude.ai/code)