### PR TITLE
fix: 多段序號標記改用 <<<SHINKANSEN_SEG-N>>> 避免弱模型誤翻

### DIFF
--- a/shinkansen/content-ns.js
+++ b/shinkansen/content-ns.js
@@ -246,19 +246,19 @@ if (window.__shinkansen_loaded) {
     return 'EXTRACT_GLOSSARY';
   };
 
-  // v1.8.10: 防禦式清理 LLM 沒照規則回時殘留的多段協定標記。
-  // 規格參見 lib/system-instruction.js DELIMITER 與 «N» 序號 prefix:
+  // 防禦式清理 LLM 沒照規則回時殘留的多段協定標記。
+  // 規格參見 lib/system-instruction.js DELIMITER 與 SEG_MARKER:
   //   - <<<SHINKANSEN_SEP>>>:多段譯文之間的分隔符
-  //   - «N»(N 為數字):每段譯文開頭的序號標記
+  //   - <<<SHINKANSEN_SEG-N>>>(N 為數字):每段譯文開頭的序號標記
   // 正常情況下 lib/gemini.js parser 已 split + 移除標記;但 LLM 偷懶把 N 段合併
   // 成 1 段回傳時(hadMismatch=true 路徑),分隔符與內段序號會殘留進譯文 string。
-  // 寫入 captionMap / DOM 之前先清理,避免使用者看到刺眼的英文標記。
+  // 寫入 captionMap / DOM 之前先清理,避免使用者看到刺眼的標記。
   // 跟 hadMismatch retry(B 路徑)是分層防禦——這條當最後一道防線。
   SK.sanitizeMarkers = function sanitizeMarkers(text) {
     if (text == null) return text;
     return String(text)
       .replace(/\s*<<<SHINKANSEN_SEP>>>\s*/g, ' ')
-      .replace(/«\d+»\s*/g, '')
+      .replace(/<<<SHINKANSEN_SEG-\d+>>>\s*/g, '')
       .trim();
   };
 

--- a/shinkansen/content-youtube.js
+++ b/shinkansen/content-youtube.js
@@ -1674,7 +1674,7 @@
         _logWindowUsage(batchUnits.length, res.usage);
         for (let j = 0; j < batchUnits.length; j++) {
           const unit = batchUnits[j];
-          // v1.8.10 A:strip LLM 偷懶殘留的 SEP / «N» 標記
+          // strip LLM 偷懶殘留的 SEP / SEG-N 標記
           const trans = SK.sanitizeMarkers(String(res.result[j] || unit.text).trim());
           let normTrans = trans;
           if (unit.keys.length === 1) {
@@ -1907,7 +1907,7 @@
         const _injectBatchResult = (batchUnits, results, b, elapsed) => {
           for (let j = 0; j < batchUnits.length; j++) {
             const unit     = batchUnits[j];
-            // v1.8.10 A:寫 captionMap 之前先 strip LLM 偷懶殘留的 SEP / «N» 標記
+            // 寫 captionMap 之前先 strip LLM 偷懶殘留的 SEP / SEG-N 標記
             const rawTrans = SK.sanitizeMarkers(results[j] || unit.text);
             if (unit.keys.length === 1) {
               YT.captionMap.set(unit.keys[0], rawTrans);
@@ -2532,7 +2532,7 @@
 
       for (let i = 0; i < texts.length; i++) {
         const key = texts[i];
-        // v1.8.10 A:strip LLM 偷懶殘留的 SEP / «N» 標記
+        // strip LLM 偷懶殘留的 SEP / SEG-N 標記
         const trans = SK.sanitizeMarkers(res.result[i] || texts[i]);
         YT.captionMap.set(key, trans);
         const isBilingual = YT.config?.bilingualMode === true;

--- a/shinkansen/content.js
+++ b/shinkansen/content.js
@@ -379,7 +379,7 @@
         }
         if (response.rpdExceeded) rpdWarning = true;
         if (response.hadMismatch) hadAnyMismatch = true;
-        // v1.8.10 A:strip LLM 偷懶殘留的 SEP / «N» 標記
+        // strip LLM 偷懶殘留的 SEP / SEG-N 標記
         // v1.8.39: dedup broadcast — 同一份譯文 broadcast 到所有 dup 原始位置，
         // 讓 60 段重複的 image alt 只翻 1 次但 inject 60 個 element。
         let injectedThisBatch = 0;
@@ -456,7 +456,7 @@
           firstChunkResolve(true);
         } else if (message.type === 'STREAMING_SEGMENT') {
           const idx = message.payload.segmentIdx;
-          // v1.8.10 A:strip LLM 偷懶殘留的 SEP / «N» 標記
+          // strip LLM 偷懶殘留的 SEP / SEG-N 標記
           const tr = SK.sanitizeMarkers(message.payload.translation);
           if (typeof idx === 'number' && idx >= 0 && idx < job.texts.length && tr) {
             try {

--- a/shinkansen/lib/gemini.js
+++ b/shinkansen/lib/gemini.js
@@ -5,7 +5,7 @@
 import { debugLog } from './logger.js';
 // v1.5.7: DELIMITER / packChunks / buildEffectiveSystemInstruction 抽到共用模組，
 // 與 lib/openai-compat.js 共用同一份「翻譯 batch 構建」邏輯。
-import { DELIMITER, packChunks, buildEffectiveSystemInstruction } from './system-instruction.js';
+import { DELIMITER, SEG_MARKER, SEQ_MARKER_RE, packChunks, buildEffectiveSystemInstruction } from './system-instruction.js';
 
 const MAX_BACKOFF_MS = 8000;
 
@@ -358,13 +358,11 @@ async function translateChunk(texts, settings, glossary, fixedGlossary, forbidde
     systemInstruction,
   } = geminiConfig;
 
-  // v0.89: 多段時加序號標記，幫助模型追蹤段數，降低 segment mismatch 機率
-  // 格式：«1» text1 <<<SHINKANSEN_SEP>>> «2» text2 ...
-  // 使用 «» 而非 [] 避免跟原文的引註 [3] 或佔位符 ⟦⟧ 衝突。
-  // parse 時會用 regex 移除每段開頭的 «N» 前綴，不會洩漏到 DOM。
+  // 多段時加序號標記，幫助模型追蹤段數，降低 segment mismatch 機率
+  // 使用 <<<SHINKANSEN_SEG-N>>> 格式避免弱模型誤翻
   const useSeqMarkers = texts.length > 1;
   const markedTexts = useSeqMarkers
-    ? texts.map((t, i) => `«${i + 1}» ${t}`)
+    ? texts.map((t, i) => `${SEG_MARKER(i + 1)} ${t}`)
     : texts;
   const joined = markedTexts.join(DELIMITER);
 
@@ -504,8 +502,7 @@ async function translateChunk(texts, settings, glossary, fixedGlossary, forbidde
     outputPreview: text.slice(0, 300),
   });
 
-  // v0.89: split 後移除序號標記 «N»（若有）
-  const SEQ_MARKER_RE = /^«\d+»\s*/;
+  // split 後移除序號標記（若有）
   const parts = text.split(DELIMITER).map(s => s.trim().replace(SEQ_MARKER_RE, ''));
   // 若回傳段數不符，且本批不只一段，則 fallback 改為逐段單獨翻譯，確保對齊
   if (parts.length !== texts.length) {
@@ -573,9 +570,9 @@ export async function translateBatchStream(texts, settings, glossary, fixedGloss
   const { apiKey, geminiConfig } = settings;
   const { model, serviceTier, temperature, topP, topK, maxOutputTokens, systemInstruction } = geminiConfig;
 
-  // 跟 translateChunk 一致:多段時加 «N» 序號標記
+  // 跟 translateChunk 一致:多段時加序號標記
   const useSeqMarkers = texts.length > 1;
-  const markedTexts = useSeqMarkers ? texts.map((t, i) => `«${i + 1}» ${t}`) : texts;
+  const markedTexts = useSeqMarkers ? texts.map((t, i) => `${SEG_MARKER(i + 1)} ${t}`) : texts;
   const joined = markedTexts.join(DELIMITER);
 
   const effectiveSystem = buildEffectiveSystemInstruction(systemInstruction, texts, joined, glossary, fixedGlossary, forbiddenTerms);
@@ -607,7 +604,6 @@ export async function translateBatchStream(texts, settings, glossary, fixedGloss
   });
 
   const t0 = Date.now();
-  const SEQ_MARKER_RE = /^«\d+»\s*/;
 
   let resp;
   try {

--- a/shinkansen/lib/openai-compat.js
+++ b/shinkansen/lib/openai-compat.js
@@ -19,7 +19,7 @@
 // 黑名單與固定術語表是「跨 provider 共用」（Jimmy 設計決定 #3）。
 
 import { debugLog } from './logger.js';
-import { DELIMITER, packChunks, buildEffectiveSystemInstruction } from './system-instruction.js';
+import { DELIMITER, SEG_MARKER, SEQ_MARKER_RE, packChunks, buildEffectiveSystemInstruction } from './system-instruction.js';
 // v1.6.18: thinking 控制 mapping（各家 provider 的 thinking schema 不同，統一成
 // thinkingLevel 'auto/off/low/medium/high' + extraBodyJson 進階透傳）
 import { buildThinkingPayload } from './openai-compat-thinking.js';
@@ -151,7 +151,7 @@ async function translateChunk(texts, settings, glossary, fixedGlossary, forbidde
   // 多段時加序號標記（與 Gemini 同邏輯）
   const useSeqMarkers = texts.length > 1;
   const markedTexts = useSeqMarkers
-    ? texts.map((t, i) => `«${i + 1}» ${t}`)
+    ? texts.map((t, i) => `${SEG_MARKER(i + 1)} ${t}`)
     : texts;
   const joined = markedTexts.join(DELIMITER);
 
@@ -249,8 +249,7 @@ async function translateChunk(texts, settings, glossary, fixedGlossary, forbidde
 
   });
 
-  // 拆分對齊（與 Gemini 同邏輯：split by DELIMITER + 移除 «N» 序號標記）
-  const SEQ_MARKER_RE = /^«\d+»\s*/;
+  // 拆分對齊（與 Gemini 同邏輯：split by DELIMITER + 移除序號標記）
   const parts = text.split(DELIMITER).map(s => s.trim().replace(SEQ_MARKER_RE, ''));
   if (parts.length !== texts.length) {
     await debugLog('warn', 'api', 'openai-compat segment count mismatch — fallback to per-segment', {
@@ -278,7 +277,7 @@ async function translateChunk(texts, settings, glossary, fixedGlossary, forbidde
  * dispatch path 下兩條 engine 都能 plug-in)。
  *
  * 走 chat.completions:system = settings.glossary.prompt、user = compressedText。
- * 不走 buildEffectiveSystemInstruction(那會插入翻譯特化規則:SEP 分隔符 / «N»
+ * 不走 buildEffectiveSystemInstruction(那會插入翻譯特化規則:SEP 分隔符 / SEG-N
  * 段序號 / 段內換行 / 佔位符 / 自動 glossary / 固定術語表 / 黑名單),術語抽取不需要。
  *
  * model:沿用 customProvider.model;為空(llama.cpp / Ollama 預設)時不送 model 欄位。

--- a/shinkansen/lib/system-instruction.js
+++ b/shinkansen/lib/system-instruction.js
@@ -27,6 +27,12 @@ import { DEFAULT_UNITS_PER_BATCH, DEFAULT_CHARS_PER_BATCH } from './constants.js
 /** 多段翻譯時用此 delimiter 串接 / 拆回對齊。Gemini 與 OpenAI-compat 共用。 */
 export const DELIMITER = '\n<<<SHINKANSEN_SEP>>>\n';
 
+/** 多段翻譯時每段開頭的序號標記。格式與 DELIMITER 一致，避免弱模型誤翻。 */
+export const SEG_MARKER = (n) => `<<<SHINKANSEN_SEG-${n}>>>`;
+
+/** 解析 LLM 回應時用來移除每段開頭的序號標記。 */
+export const SEQ_MARKER_RE = /^<<<SHINKANSEN_SEG-\d+>>>\s*/;
+
 const MAX_UNITS_PER_CHUNK = DEFAULT_UNITS_PER_BATCH;
 const MAX_CHARS_PER_CHUNK = DEFAULT_CHARS_PER_BATCH;
 
@@ -46,6 +52,8 @@ function sanitizeTermText(s) {
     .replace(/⟦\/?\*?\d+⟧/g, '')
     // 多段 sentinel(防止假冒批次切分標記)
     .replace(/<<<SHINKANSEN_SEP>>>/gi, '')
+    // 多段序號標記(防止假冒段落序號)
+    .replace(/<<<SHINKANSEN_SEG-\d+>>>/gi, '')
     // forbidden_terms_blacklist 標籤(防止使用者輸入提前關閉區塊)
     .replace(/<\/?forbidden_terms_blacklist>/gi, '')
     .trim()
@@ -177,7 +185,7 @@ export function buildEffectiveSystemInstruction(baseSystem, texts, joined, gloss
   // 多段翻譯分隔符與序號規則(嵌入 batch 段數 N,batch 級變動;放最末端讓前段 cache 共享)
   if (texts.length > 1) {
     parts.push(
-      `額外規則（多段翻譯分隔符與序號，極重要）:\n本批次包含 ${texts.length} 段文字。每段開頭有序號標記 «N»（N 為 1 到 ${texts.length}），段與段之間以分隔符 <<<SHINKANSEN_SEP>>> 隔開。\n你的輸出必須：\n- 每段譯文開頭也加上對應的序號標記 «N»（N 與輸入的序號一一對應）\n- 段與段之間用完全相同的分隔符 <<<SHINKANSEN_SEP>>> 隔開\n- 恰好輸出 ${texts.length} 段譯文和 ${texts.length - 1} 個分隔符\n- 不可合併段落、不可省略分隔符、不可增減段數`
+      `額外規則（多段翻譯分隔符與序號，極重要）:\n本批次包含 ${texts.length} 段文字。每段開頭有序號標記 <<<SHINKANSEN_SEG-N>>>（N 為 1 到 ${texts.length}），段與段之間以分隔符 <<<SHINKANSEN_SEP>>> 隔開。\n你的輸出必須：\n- 每段譯文開頭也加上對應的序號標記 <<<SHINKANSEN_SEG-N>>>（N 與輸入的序號一一對應）\n- 段與段之間用完全相同的分隔符 <<<SHINKANSEN_SEP>>> 隔開\n- 恰好輸出 ${texts.length} 段譯文和 ${texts.length - 1} 個分隔符\n- 不可合併段落、不可省略分隔符、不可增減段數`
     );
   }
 

--- a/test/regression/sanitize-marker-leak.spec.js
+++ b/test/regression/sanitize-marker-leak.spec.js
@@ -1,9 +1,9 @@
 // Regression: v1.8.10 A — SK.sanitizeMarkers strip LLM 偷懶殘留的多段協定標記
 //
-// 背景:lib/system-instruction.js 把多段譯文用 <<<SHINKANSEN_SEP>>> 分隔 + 每段加 «N» 序號。
+// 背景:lib/system-instruction.js 把多段譯文用 <<<SHINKANSEN_SEP>>> 分隔 + 每段加 <<<SHINKANSEN_SEG-N>>> 序號。
 // 正常情況下 lib/gemini.js parser 在 split 時會清掉這些標記。但 LLM 偷懶把 N 段合併成 1 段
 // (translations.length=1 ≠ texts.length=N → hadMismatch=true)時,合併版字串會帶完整的
-// SEP / «N» 進到 translations[0],一路寫進 captionMap / DOM,使用者看到「中文 + <<<SEP>>> + «2» + 中文」。
+// SEP / SEG-N 進到 translations[0],一路寫進 captionMap / DOM。
 //
 // A 路徑(本 spec):defensive sanitize at write time——content-ns.js 加 SK.sanitizeMarkers,
 // 字幕 _injectBatchResult / 文章 runBatch & STREAMING_SEGMENT inject 時呼叫,strip 殘留標記。
@@ -19,7 +19,7 @@ import { getShinkansenEvaluator } from './helpers/run-inject.js';
 
 const FIXTURE = 'youtube-streaming-inject';
 
-test('sanitize-marker-leak (case 1): SK.sanitizeMarkers 直接呼叫 strip SEP / «N»', async ({
+test('sanitize-marker-leak (case 1): SK.sanitizeMarkers 直接呼叫 strip SEP / SEG-N', async ({
   context,
   localServer,
 }) => {
@@ -30,12 +30,12 @@ test('sanitize-marker-leak (case 1): SK.sanitizeMarkers 直接呼叫 strip SEP /
 
   const cases = [
     {
-      input: '«1» 第一句譯文 <<<SHINKANSEN_SEP>>> «2» 第二句譯文',
+      input: '<<<SHINKANSEN_SEG-1>>> 第一句譯文 <<<SHINKANSEN_SEP>>> <<<SHINKANSEN_SEG-2>>> 第二句譯文',
       expect: '第一句譯文 第二句譯文',
-      desc: 'SEP + «N» 都殘留',
+      desc: 'SEP + SEG-N 都殘留',
     },
     { input: '<<<SHINKANSEN_SEP>>>', expect: '', desc: '只有 SEP' },
-    { input: '«1» 純 «N» 開頭', expect: '純 «N» 開頭', desc: '只有 «1» 開頭(注意:正則只清一次)' },
+    { input: '<<<SHINKANSEN_SEG-1>>> 純序號開頭', expect: '純序號開頭', desc: '只有 SEG-1 開頭' },
     { input: '正常譯文沒有標記', expect: '正常譯文沒有標記', desc: '無標記應原樣回傳' },
     { input: '', expect: '', desc: '空字串' },
     { input: null, expect: null, desc: 'null 應原樣回(防禦式)' },
@@ -49,7 +49,7 @@ test('sanitize-marker-leak (case 1): SK.sanitizeMarkers 直接呼叫 strip SEP /
   await page.close();
 });
 
-test('sanitize-marker-leak (case 2): TRANSLATE_SUBTITLE_BATCH 回譯文含 SEP/«N» → captionMap 已清', async ({
+test('sanitize-marker-leak (case 2): TRANSLATE_SUBTITLE_BATCH 回譯文含 SEP/SEG-N → captionMap 已清', async ({
   context,
   localServer,
 }) => {
@@ -67,10 +67,10 @@ test('sanitize-marker-leak (case 2): TRANSLATE_SUBTITLE_BATCH 回譯文含 SEP/�
       }
       if (msg && msg.type === 'TRANSLATE_SUBTITLE_BATCH') {
         const texts = msg.payload.texts || [];
-        // 模擬 LLM 偷懶:texts[0] 回完整合併版含 SEP / «N»,其餘空字串
+        // 模擬 LLM 偷懶:texts[0] 回完整合併版含 SEP / SEG-N,其餘空字串
         const result = texts.map((_, i) =>
           i === 0
-            ? '«1» 第一句中文譯文 <<<SHINKANSEN_SEP>>> «2» 第二句譯文 <<<SHINKANSEN_SEP>>> «3» 第三句譯文'
+            ? '<<<SHINKANSEN_SEG-1>>> 第一句中文譯文 <<<SHINKANSEN_SEP>>> <<<SHINKANSEN_SEG-2>>> 第二句譯文 <<<SHINKANSEN_SEP>>> <<<SHINKANSEN_SEG-3>>> 第三句譯文'
             : ''
         );
         return {
@@ -96,12 +96,12 @@ test('sanitize-marker-leak (case 2): TRANSLATE_SUBTITLE_BATCH 回譯文含 SEP/�
     captionMapEntries: Array.from(window.__SK.YT.captionMap.entries()),
   })`);
 
-  // captionMap 應含 line 0 的譯文,內容不該有 SEP / «N»
+  // captionMap 應含 line 0 的譯文,內容不該有 SEP / SEG-N
   const entry0 = result.captionMapEntries.find(([k]) => k === 'line 0');
   expect(entry0, 'line 0 應有 captionMap entry').toBeTruthy();
   const trans0 = entry0[1];
   expect(trans0.includes('<<<SHINKANSEN_SEP>>>'), `line 0 譯文不該含 SEP(實際:${trans0})`).toBe(false);
-  expect(/«\d+»/.test(trans0), `line 0 譯文不該含 «N»(實際:${trans0})`).toBe(false);
+  expect(/<<<SHINKANSEN_SEG-\d+>>>/.test(trans0), `line 0 譯文不該含 SEG-N(實際:${trans0})`).toBe(false);
   // 應該包含合併後的中文(三句連在一起)
   expect(trans0.includes('第一句中文譯文'), `line 0 譯文應含「第一句中文譯文」`).toBe(true);
   expect(trans0.includes('第二句譯文'), `line 0 譯文應含「第二句譯文」`).toBe(true);

--- a/test/regression/streaming-batch-0-mismatch-retry.spec.js
+++ b/test/regression/streaming-batch-0-mismatch-retry.spec.js
@@ -58,7 +58,7 @@ test('streaming-batch-0-mismatch-retry (case 1): 文章 streaming hadMismatch=tr
           for (const fn of window.__listeners) {
             fn({ type: 'STREAMING_SEGMENT', payload: {
               streamId, segmentIdx: 0,
-              translation: '«1» 合併內容 <<<SHINKANSEN_SEP>>> «2» 跑進來了 <<<SHINKANSEN_SEP>>> «3» 全部塞進 idx 0',
+              translation: '<<<SHINKANSEN_SEG-1>>> 合併內容 <<<SHINKANSEN_SEP>>> <<<SHINKANSEN_SEG-2>>> 跑進來了 <<<SHINKANSEN_SEP>>> <<<SHINKANSEN_SEG-3>>> 全部塞進 idx 0',
             } });
           }
         }, 50);
@@ -150,7 +150,7 @@ test('streaming-batch-0-mismatch-retry (case 2): 字幕 streaming hadMismatch=tr
           for (const fn of window.__listeners) {
             fn({ type: 'STREAMING_SEGMENT', payload: {
               streamId, segmentIdx: 0,
-              translation: '«1» 第一句中文 <<<SHINKANSEN_SEP>>> «2» 第二句中文',
+              translation: '<<<SHINKANSEN_SEG-1>>> 第一句中文 <<<SHINKANSEN_SEP>>> <<<SHINKANSEN_SEG-2>>> 第二句中文',
             } });
           }
         }, 50);

--- a/test/unit/openai-compat-segment-mismatch.spec.js
+++ b/test/unit/openai-compat-segment-mismatch.spec.js
@@ -27,8 +27,8 @@ globalThis.fetch = async (_url, options) => {
     // 故意把多段譯文合併成一段（不含分隔符）→ split 出來只有 1 段，與 segCount 不符
     respText = '合併後的單段譯文';
   } else {
-    // 對齊回應：每段照樣產生「«N» 段譯」並用 SEP 串接
-    const parts = userText.split('\n<<<SHINKANSEN_SEP>>>\n').map((_t, i) => `«${i + 1}» 段譯${i + 1}`);
+    // 對齊回應：每段照樣產生序號標記 + 段譯並用 SEP 串接
+    const parts = userText.split('\n<<<SHINKANSEN_SEP>>>\n').map((_t, i) => `<<<SHINKANSEN_SEG-${i + 1}>>> 段譯${i + 1}`);
     respText = parts.join('\n<<<SHINKANSEN_SEP>>>\n');
   }
   return {

--- a/test/unit/streaming-batch-incremental.spec.js
+++ b/test/unit/streaming-batch-incremental.spec.js
@@ -88,11 +88,11 @@ test.afterEach(() => {
 test('translateBatchStream: 每段 segment 收齊後立即 emit(incremental)', async () => {
   // 3 段譯文,每段一個 SSE event,中間有 SEP
   globalThis.fetch = async () => makeStreamResponse([
-    sseEvent(chunkData('«1» 段一譯文')),
+    sseEvent(chunkData('<<<SHINKANSEN_SEG-1>>> 段一譯文')),
     sseEvent(chunkData(SEP)),
-    sseEvent(chunkData('«2» 段二譯文')),
+    sseEvent(chunkData('<<<SHINKANSEN_SEG-2>>> 段二譯文')),
     sseEvent(chunkData(SEP)),
-    sseEvent(chunkData('«3» 段三譯文', 'STOP', { promptTokenCount: 10, candidatesTokenCount: 6, totalTokenCount: 16 })),
+    sseEvent(chunkData('<<<SHINKANSEN_SEG-3>>> 段三譯文', 'STOP', { promptTokenCount: 10, candidatesTokenCount: 6, totalTokenCount: 16 })),
   ]);
 
   const segments = [];
@@ -125,7 +125,7 @@ test('translateBatchStream: 每段 segment 收齊後立即 emit(incremental)', a
 
 test('translateBatchStream: SSE event 切在 chunk 中間,parser 仍能完整解出', async () => {
   // 把單一 SSE event 切成 3 個 chunks(模擬 TCP fragment)
-  const fullEvent = sseEvent(chunkData('«1» 完整段', 'STOP', { promptTokenCount: 5, candidatesTokenCount: 4 }));
+  const fullEvent = sseEvent(chunkData('<<<SHINKANSEN_SEG-1>>> 完整段', 'STOP', { promptTokenCount: 5, candidatesTokenCount: 4 }));
   const splitChunks = [
     fullEvent.slice(0, 30),
     fullEvent.slice(30, 60),
@@ -149,10 +149,10 @@ test('translateBatchStream: SSE event 切在 chunk 中間,parser 仍能完整解
 
 test('translateBatchStream: 占位符 ⟦/0⟧ 切在 SSE chunk 中間,parser 仍能完整解出', async () => {
   // 模擬:譯文「⟦0⟧第一段⟦/0⟧」被切成 ⟦0⟧第一段⟦/ + 0⟧ 兩個 chunk
-  const event1 = sseEvent(chunkData('«1» ⟦0⟧第一段⟦/'));
+  const event1 = sseEvent(chunkData('<<<SHINKANSEN_SEG-1>>> ⟦0⟧第一段⟦/'));
   const event2 = sseEvent(chunkData('0⟧'));
   const event3 = sseEvent(chunkData(SEP));
-  const event4 = sseEvent(chunkData('«2» ⟦0⟧第二段⟦/0⟧', 'STOP', { promptTokenCount: 8, candidatesTokenCount: 5 }));
+  const event4 = sseEvent(chunkData('<<<SHINKANSEN_SEG-2>>> ⟦0⟧第二段⟦/0⟧', 'STOP', { promptTokenCount: 8, candidatesTokenCount: 5 }));
 
   globalThis.fetch = async () => makeStreamResponse([event1, event2, event3, event4]);
 
@@ -175,9 +175,9 @@ test('translateBatchStream: 占位符 ⟦/0⟧ 切在 SSE chunk 中間,parser �
 test('translateBatchStream: hadMismatch 在段數不對時回 true', async () => {
   // 預期 3 段,但 LLM 只回 2 段(SEP 數量不對)
   globalThis.fetch = async () => makeStreamResponse([
-    sseEvent(chunkData('«1» 一')),
+    sseEvent(chunkData('<<<SHINKANSEN_SEG-1>>> 一')),
     sseEvent(chunkData(SEP)),
-    sseEvent(chunkData('«2» 二', 'STOP', { promptTokenCount: 5, candidatesTokenCount: 3 })),
+    sseEvent(chunkData('<<<SHINKANSEN_SEG-2>>> 二', 'STOP', { promptTokenCount: 5, candidatesTokenCount: 3 })),
   ]);
 
   const segments = [];
@@ -211,7 +211,7 @@ test('translateBatchStream: AbortSignal 抵達後,read 拋 AbortError → 函式
           }, { once: true });
         }
         // 持續發 chunk(永不 close)
-        controller.enqueue(ENC.encode(sseEvent(chunkData('«1» 段'))));
+        controller.enqueue(ENC.encode(sseEvent(chunkData('<<<SHINKANSEN_SEG-1>>> 段'))));
       },
     });
     return { ok: true, status: 200, body: stream };

--- a/test/unit/system-instruction-sanitize.spec.js
+++ b/test/unit/system-instruction-sanitize.spec.js
@@ -27,6 +27,13 @@ test('sanitize: SHINKANSEN_SEP token 不外洩到 system instruction', () => {
   expect(out).toContain('maliciousTerm');
 });
 
+test('sanitize: SHINKANSEN_SEG-N token 不外洩到 system instruction', () => {
+  const glossary = [{ source: '<<<SHINKANSEN_SEG-1>>>injection', target: '注入' }];
+  const out = buildEffectiveSystemInstruction(baseSystem, ['hello'], 'hello', glossary);
+  expect(out).not.toContain('<<<SHINKANSEN_SEG-1>>>');
+  expect(out).toContain('injection');
+});
+
 test('sanitize: forbidden_terms_blacklist 結束標籤被 strip 防提前關閉區塊', () => {
   const forbidden = [
     { forbidden: '視頻</forbidden_terms_blacklist>注入規則', replacement: '影片' },


### PR DESCRIPTION
## Summary

- Local LLM（如 gemma-4 量化版）會把舊格式 `«1»` `«2»` 誤譯為 N1, N2
- 改用 `<<<SHINKANSEN_SEG-N>>>` 格式，與既有的 `<<<SHINKANSEN_SEP>>>` 風格一致，長度夠明��不會被誤翻
- 新增共用常數 `SEG_MARKER()` / `SEQ_MARKER_RE`，消除 gemini.js / openai-compat.js 各自定義的重複 regex

## Changes

- `lib/system-instruction.js` — 新增 exports + `sanitizeTermText()` 加入 SEG-N 防注入 + 更新 LLM instruction
- `lib/gemini.js` — batch + streaming 兩條路徑改用共用常數
- `lib/openai-compat.js` — 改用共用常數
- `content-ns.js` — 更新 defensive sanitizer regex
- `content.js` / `content-youtube.js` — 註解更新
- 6 個 test files 同步更新

## Test plan

- [x] `npx playwright test test/unit/` — 344 tests passed
- [x] 手動測試：載入 extension → YouTube 字幕翻譯（local LLM backend）→ 確認無 `<<<SHINKANSEN_SEG-N>>>` 洩漏到字幕、無 N1/N2 殘留

🤖 Generated with [Claude Code](https://claude.com/claude-code)