### PR TITLE
feat: translate-doc custom/local provider support

### DIFF
--- a/shinkansen/background.js
+++ b/shinkansen/background.js
@@ -210,6 +210,38 @@ function resolveCustomProviderCachedRate(cp) {
   return getCustomCacheHitRate(cp?.baseUrl);
 }
 
+function buildFixedGlossaryEntries(fixedGlossary, sender) {
+  if (!fixedGlossary) return null;
+  const globalEntries = Array.isArray(fixedGlossary.global)
+    ? fixedGlossary.global.filter((e) => e.source && e.target)
+    : [];
+  let domainEntries = [];
+  if (fixedGlossary.byDomain && sender?.tab?.url) {
+    try {
+      const hostname = new URL(sender.tab.url).hostname;
+      domainEntries = Array.isArray(fixedGlossary.byDomain[hostname])
+        ? fixedGlossary.byDomain[hostname].filter((e) => e.source && e.target)
+        : [];
+    } catch { /* invalid URL */ }
+  }
+  if (globalEntries.length === 0 && domainEntries.length === 0) return null;
+  const merged = new Map();
+  for (const entry of globalEntries) merged.set(entry.source, entry.target);
+  for (const entry of domainEntries) merged.set(entry.source, entry.target);
+  return [...merged.entries()].map(([source, target]) => ({ source, target }));
+}
+
+function preferArticleGlossaryEntries(fixedGlossaryEntries, articleGlossary, enabled) {
+  if (!enabled
+      || !Array.isArray(articleGlossary) || articleGlossary.length === 0
+      || !Array.isArray(fixedGlossaryEntries) || fixedGlossaryEntries.length === 0) {
+    return fixedGlossaryEntries;
+  }
+  const articleSources = new Set(articleGlossary.map((entry) => entry.source));
+  const filtered = fixedGlossaryEntries.filter((entry) => !articleSources.has(entry.source));
+  return filtered.length > 0 ? filtered : null;
+}
+
 // ─── Extension icon badge（已翻譯紅點提示） ─────────────────
 // 使用浮世繪圖示上的旭日紅 #cf3a2c，視覺上延續「太陽」的意象。
 const BADGE_COLOR = '#cf3a2c';
@@ -580,6 +612,21 @@ const messageHandlers = {
       // fixedGlossary entries 仍從 settings.fixedGlossary.global 讀（跟主功能共用)。
       const applyFixedGlossary = td.applyFixedGlossary !== false;
       return handleTranslate(payload, sender, overrides, null, '_doc', applyFixedGlossary);
+    },
+  },
+  TRANSLATE_DOC_BATCH_CUSTOM: {
+    async: true,
+    handler: async (payload, sender) => {
+      const s = await getSettings();
+      const td = s.translateDoc || {};
+      const userPrompt = getEffectiveDocSystemPrompt(s.targetLanguage, td.systemPrompt);
+      const effectivePrompt = userPrompt + DOC_INLINE_MARKER_INSTRUCTION;
+      const overrides = { systemPrompt: effectivePrompt };
+      if (typeof td.temperature === 'number' && Number.isFinite(td.temperature)) {
+        overrides.temperature = td.temperature;
+      }
+      const applyFixedGlossary = td.applyFixedGlossary !== false;
+      return handleTranslateCustom(payload, sender, '_oc_doc', overrides, applyFixedGlossary);
     },
   },
   // commit 5b:Drive 影片字幕走 Google Translate 路徑（獨立 cache key '_gt_drive' 避免跟
@@ -1249,37 +1296,19 @@ async function handleTranslate(payload, sender, geminiOverrides = {}, pricingOve
 
   // v1.0.29: 讀取固定術語表（全域 + 當前網域），合併後傳給 translateBatch
   // v1.5.8: 字幕路徑（applyFixedGlossary=false）跳過讀取，省 prompt token
-  let fixedGlossaryEntries = null;
-  const fg = applyFixedGlossary ? settings.fixedGlossary : null;
-  if (fg) {
-    const globalEntries = Array.isArray(fg.global) ? fg.global.filter(e => e.source && e.target) : [];
-    let domainEntries = [];
-    if (fg.byDomain && sender?.tab?.url) {
-      try {
-        const hostname = new URL(sender.tab.url).hostname;
-        domainEntries = Array.isArray(fg.byDomain[hostname]) ? fg.byDomain[hostname].filter(e => e.source && e.target) : [];
-      } catch { /* 無效 URL，略過 */ }
-    }
-    // 合併：全域先、網域後（網域覆蓋全域同名術語——用 Map 去重，後出現的覆蓋前面的）
-    if (globalEntries.length > 0 || domainEntries.length > 0) {
-      const merged = new Map();
-      for (const e of globalEntries) merged.set(e.source, e.target);
-      for (const e of domainEntries) merged.set(e.source, e.target); // 網域覆蓋全域
-      fixedGlossaryEntries = [...merged.entries()].map(([source, target]) => ({ source, target }));
-    }
-  }
+  let fixedGlossaryEntries = buildFixedGlossaryEntries(
+    applyFixedGlossary ? settings.fixedGlossary : null,
+    sender,
+  );
 
   // v1.8.49: preferArticleGlossary 時（文件翻譯 path 帶來)，把跟文章術語表同 source 的
   // fixed entry 從 fixedGlossary 移除，讓 article 完全 override fixed(不靠 LLM 判斷
   // 優先級，直接從 prompt 拿掉避免衝突)
-  const payloadGlossary = payload?.glossary;
-  if (payload?.preferArticleGlossary
-      && Array.isArray(payloadGlossary) && payloadGlossary.length > 0
-      && fixedGlossaryEntries && fixedGlossaryEntries.length > 0) {
-    const articleSources = new Set(payloadGlossary.map((e) => e.source));
-    fixedGlossaryEntries = fixedGlossaryEntries.filter((e) => !articleSources.has(e.source));
-    if (fixedGlossaryEntries.length === 0) fixedGlossaryEntries = null;
-  }
+  fixedGlossaryEntries = preferArticleGlossaryEntries(
+    fixedGlossaryEntries,
+    payload?.glossary,
+    payload?.preferArticleGlossary,
+  );
 
   // v1.5.6: 中國用語黑名單。從 settings 讀清單後一路傳到 translateBatch（注入到 systemInstruction），
   // 同時計算 hash 加進 cache key 後綴，讓使用者修改清單後既有快取自動失效。
@@ -1548,24 +1577,17 @@ async function handleTranslateCustom(payload, sender, cacheTag = '_oc', cpOverri
 
   // 重用 handleTranslate 內的 fixedGlossary 合併邏輯
   // v1.5.8: 字幕路徑（applyFixedGlossary=false）跳過
-  let fixedGlossaryEntries = null;
-  const fg = applyFixedGlossary ? settings.fixedGlossary : null;
-  if (fg) {
-    const globalEntries = Array.isArray(fg.global) ? fg.global.filter(e => e.source && e.target) : [];
-    let domainEntries = [];
-    if (fg.byDomain && sender?.tab?.url) {
-      try {
-        const hostname = new URL(sender.tab.url).hostname;
-        domainEntries = Array.isArray(fg.byDomain[hostname]) ? fg.byDomain[hostname].filter(e => e.source && e.target) : [];
-      } catch { /* 無效 URL，略過 */ }
-    }
-    if (globalEntries.length > 0 || domainEntries.length > 0) {
-      const merged = new Map();
-      for (const e of globalEntries) merged.set(e.source, e.target);
-      for (const e of domainEntries) merged.set(e.source, e.target);
-      fixedGlossaryEntries = [...merged.entries()].map(([source, target]) => ({ source, target }));
-    }
-  }
+  let fixedGlossaryEntries = buildFixedGlossaryEntries(
+    applyFixedGlossary ? settings.fixedGlossary : null,
+    sender,
+  );
+
+  // preferArticleGlossary dedup: article glossary overrides fixed entries with same source
+  fixedGlossaryEntries = preferArticleGlossaryEntries(
+    fixedGlossaryEntries,
+    payload?.glossary,
+    payload?.preferArticleGlossary,
+  );
 
   // v1.5.8: 字幕路徑（applyForbiddenTerms=false）跳過
   const forbiddenTermsList = (applyForbiddenTerms && Array.isArray(settings.forbiddenTerms))
@@ -1593,6 +1615,9 @@ async function handleTranslateCustom(payload, sender, cacheTag = '_oc', cpOverri
   const tl = settings.targetLanguage;
   if (tl && tl !== 'zh-TW') {
     suffix += '_lang' + tl.replace(/[^a-z0-9]/gi, '');
+  }
+  if (cacheTag === '_oc_doc' && typeof cp.temperature === 'number' && Number.isFinite(cp.temperature)) {
+    suffix += '_t' + cp.temperature.toFixed(2);
   }
 
   // 1. 撈快取

--- a/shinkansen/lib/i18n.js
+++ b/shinkansen/lib/i18n.js
@@ -615,7 +615,7 @@
 
     'doc.settings.title': '翻譯設定',
     'doc.settings.label.preset': '使用哪組預設',
-    'doc.settings.hint.preset': '三組預設的引擎、模型、標籤在「設定 → 翻譯快速鍵」分頁自訂',
+    'doc.settings.hint.preset': '三組預設的引擎、模型、標籤在「設定 → 翻譯快速鍵」分頁自訂。注意：文件翻譯目前不支援 Google Translate 預設',
     'doc.settings.label.docCache': '本篇翻譯記憶',
     'doc.settings.btn.clearDocCache': '清除本篇翻譯記憶',
     'doc.settings.hint.docCache': '只清掉這份文件的翻譯記憶（其他文件 / 網頁 / 字幕不影響）。清除後下次翻這份會重新呼叫 AI 翻譯。適合「覺得譯文有錯想重來」「想換個翻譯指令重試」的情境',
@@ -1379,7 +1379,7 @@
 
     'doc.settings.title': '翻译设置',
     'doc.settings.label.preset': '使用哪组预设',
-    'doc.settings.hint.preset': '三组预设的引擎、模型、标签可在「设置 → 翻译快捷键」分页中自定义',
+    'doc.settings.hint.preset': '三组预设的引擎、模型、标签可在「设置 → 翻译快捷键」分页中自定义。注意：文档翻译目前不支持 Google Translate 预设',
     'doc.settings.label.docCache': '本篇翻译记忆',
     'doc.settings.btn.clearDocCache': '清除本篇翻译记忆',
     'doc.settings.hint.docCache': '只清除这份文档的翻译记忆（其他文档 / 网页 / 字幕不受影响）。清除后下次翻这份文档会重新调用 AI 翻译。适合「觉得译文有错想重来」「想换个翻译指令重试」的场景',
@@ -2142,7 +2142,7 @@
 
     'doc.settings.title': 'Translation settings',
     'doc.settings.label.preset': 'Which preset to use',
-    'doc.settings.hint.preset': 'Configure the engine, model, and label for each preset in "Settings → Shortcut presets".',
+    'doc.settings.hint.preset': 'Configure the engine, model, and label for each preset in "Settings → Shortcut presets". Note: document translation does not currently support Google Translate presets.',
     'doc.settings.label.docCache': 'This document\'s translation memory',
     'doc.settings.btn.clearDocCache': 'Clear this document\'s translation memory',
     'doc.settings.hint.docCache': 'Clears only this document\'s translation memory (other documents / web pages / subtitles are unaffected). Re-translating this document afterwards will call the AI again. Useful when the translation looks wrong or you want to retry with a different prompt.',

--- a/shinkansen/translate-doc/index.js
+++ b/shinkansen/translate-doc/index.js
@@ -43,6 +43,7 @@ let currentPdfDoc = null;    // PDF.js PDFDocumentProxy（記得 destroy）
 let currentDebugPage = 0;
 let currentReaderHandle = null;
 let currentModelOverride = null;
+let currentEngine = 'gemini';
 let currentOriginalArrayBuffer = null; // W6：留 PDF 原 ArrayBuffer 給 pdf-lib 重組譯文 PDF 用
 let lastTranslateSummary = null;       // 翻譯紀錄 modal 顯示用
 // 翻譯設定：選定 preset slot(1 / 2 / 3)，從 storage.local.translateDocPresetSlot 讀，
@@ -100,6 +101,7 @@ function releaseCurrentDoc() {
   currentDoc = null;
   currentDebugPage = 0;
   currentModelOverride = null;
+  currentEngine = 'gemini';
   currentOriginalArrayBuffer = null;
   lastTranslateSummary = null;
   currentArticleGlossary = null;
@@ -1120,15 +1122,17 @@ async function sha1(text) {
   return Array.from(new Uint8Array(hash)).map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
-// 翻譯設定：讀使用者選定 slot，取對應 preset 的 model 當 modelOverride。
-// 不存在 / Google MT(model 為 null)時 modelOverride = undefined，讓 background
-// 走全域 geminiConfig.model 預設
-async function resolveModelOverride() {
+// 翻譯設定：讀使用者選定 slot，解析 engine + modelOverride。
+// engine='gemini' 時 modelOverride = preset.model（若有）；
+// 其他 engine（google / openai-compat）不走 Gemini model override。
+async function resolvePreset() {
   const presets = await loadPresets();
   const idx = (currentPresetSlot || 1) - 1;
   const p = presets[idx];
-  if (p && p.engine === 'gemini' && p.model) return p.model;
-  return undefined;
+  if (!p) return { engine: 'gemini', modelOverride: undefined };
+  const engine = p.engine || 'gemini';
+  const modelOverride = (engine === 'gemini' && p.model) ? p.model : undefined;
+  return { engine, modelOverride };
 }
 
 async function loadPresets() {
@@ -1440,8 +1444,8 @@ async function openReader() {
     $('reader-col-translated'),
     {
       modelOverride: currentModelOverride,
-      // v1.8.49 起「重試失敗」按鈕搬進「翻譯紀錄」modal,reader toolbar 不再顯示
-      // 失敗段數;onFailedCountChange 用 reader.js 的 default no-op
+      engine: currentEngine,
+      glossary: currentArticleGlossary,
     },
   );
   // 套用 sync toggle + 重設 zoom 顯示
@@ -2001,9 +2005,9 @@ function bindFindReplaceUI() {
 async function startTranslate() {
   if (!currentDoc) return;
 
-  // 從翻譯設定選定的 preset slot 拿 modelOverride
-  const modelOverride = await resolveModelOverride();
+  const { engine, modelOverride } = await resolvePreset();
   currentModelOverride = modelOverride;
+  currentEngine = engine;
 
   showStage('translating');
   setProgress({
@@ -2030,6 +2034,7 @@ async function startTranslate() {
   try {
     summary = await translateDocument(currentDoc, {
       modelOverride,
+      engine,
       glossary,
       signal: translateAbortController.signal,
       onProgress: setProgress,

--- a/shinkansen/translate-doc/reader.js
+++ b/shinkansen/translate-doc/reader.js
@@ -41,7 +41,7 @@ const SCROLL_SYNC_RESET_MS = 250;
  * @returns {Promise<ReaderHandle>}
  */
 export async function renderReader(doc, originalPdfDoc, originalArrayBuffer, originalCol, translatedCol, opts = {}) {
-  const { modelOverride, onFailedCountChange = () => {} } = opts;
+  const { modelOverride, engine, glossary, onFailedCountChange = () => {} } = opts;
   let currentZoom = opts.initialZoom || 1.0;
   let syncEnabled = opts.initialSyncEnabled !== false;
 
@@ -179,7 +179,7 @@ export async function renderReader(doc, originalPdfDoc, originalArrayBuffer, ori
       }
       let success = 0;
       for (const block of failed) {
-        const r = await translateSingleBlock(block, { modelOverride });
+        const r = await translateSingleBlock(block, { modelOverride, engine, glossary });
         if (r.ok) success++;
       }
       // 至少有 1 個重翻成功 → 重建譯文 PDF + 重 render 右欄

--- a/shinkansen/translate-doc/translate.js
+++ b/shinkansen/translate-doc/translate.js
@@ -3,7 +3,8 @@
 // 職責：
 //   1. 從版面 IR 收集所有「送翻譯」類 block(SPEC §17.4.4)
 //   2. 切 chunk(預設 CHUNK_SIZE = 20，跟 content.js 對齊)
-//   3. 逐 chunk 透過 chrome.runtime.sendMessage 送 background 的 TRANSLATE_DOC_BATCH
+//   3. 逐 chunk 透過 chrome.runtime.sendMessage 送 background 的文件翻譯 handler
+//      (Gemini = TRANSLATE_DOC_BATCH / custom provider = TRANSLATE_DOC_BATCH_CUSTOM)
 //   4. 結果寫回 IR(每 block.translation / .translationStatus / .translationError)
 //   5. 每完成一批 emit progress(SPEC §17.5.4 結構)
 //
@@ -25,12 +26,13 @@ const TRANSLATABLE_TYPES = new Set(['paragraph', 'heading', 'list-item', 'captio
  * @param {object}    options
  * @param {string}    [options.modelOverride] — preset 對應的 Gemini model id
  * @param {Array}     [options.glossary]      — 額外術語表(可選)
+ * @param {string}    [options.engine]        — 'gemini' | 'openai-compat'，預設 gemini
  * @param {AbortSignal} [options.signal]      — 取消信號
  * @param {(progress: TranslateProgress) => void} [options.onProgress]
  * @returns {Promise<TranslateSummary>}
  */
 export async function translateDocument(doc, options = {}) {
-  const { modelOverride, glossary, signal, onProgress = () => {} } = options;
+  const { modelOverride, glossary, signal, onProgress = () => {}, engine = 'gemini' } = options;
   const startTime = Date.now();
 
   // 1) 收集所有需翻譯 block(扁平化，保 order 用 readingOrder + page)
@@ -87,10 +89,9 @@ export async function translateDocument(doc, options = {}) {
     const t0 = Date.now();
     let response;
     try {
+      const messageType = engine === 'openai-compat' ? 'TRANSLATE_DOC_BATCH_CUSTOM' : 'TRANSLATE_DOC_BATCH';
       response = await chrome.runtime.sendMessage({
-        type: 'TRANSLATE_DOC_BATCH',
-        // v1.8.49: preferArticleGlossary 通知 background 用文章術語表 source 去 dedupe
-        // 固定術語表的同 source entry(article 覆蓋 fixed,只在 doc 路徑生效)
+        type: messageType,
         payload: { texts, modelOverride, glossary, preferArticleGlossary: true },
       });
     } catch (err) {
@@ -194,7 +195,7 @@ export async function translateDocument(doc, options = {}) {
         cacheHits,
         durationMs,
         timestamp: Date.now(),
-        engine: 'gemini',
+        engine: engine || 'gemini',
         model: modelOverride || null,
         source: 'translate-doc',
       },
@@ -244,10 +245,11 @@ export async function translateDocument(doc, options = {}) {
  * @param {object} options
  * @param {string} [options.modelOverride]
  * @param {Array}  [options.glossary]
+ * @param {string} [options.engine]
  * @returns {Promise<{ ok: boolean, error?: string }>}
  */
 export async function translateSingleBlock(block, options = {}) {
-  const { modelOverride, glossary } = options;
+  const { modelOverride, glossary, engine = 'gemini' } = options;
   if (!block || !block.plainText) return { ok: false, error: 'no plainText' };
 
   console.log('[Shinkansen] retry block', block.blockId, 'modelOverride=', modelOverride || '(default)');
@@ -258,10 +260,9 @@ export async function translateSingleBlock(block, options = {}) {
 
   let response;
   try {
+    const messageType = engine === 'openai-compat' ? 'TRANSLATE_DOC_BATCH_CUSTOM' : 'TRANSLATE_DOC_BATCH';
     response = await chrome.runtime.sendMessage({
-      type: 'TRANSLATE_DOC_BATCH',
-      // W7:retry 也走 marker 路徑,確保跟主翻譯流程一致
-      // v1.8.49:retry 也帶 preferArticleGlossary 讓 article glossary 覆蓋 fixed
+      type: messageType,
       payload: { texts: [buildMarkedText(block)], modelOverride, glossary, preferArticleGlossary: true },
     });
   } catch (err) {
@@ -297,7 +298,7 @@ export async function translateSingleBlock(block, options = {}) {
         cacheHits: usage.cacheHits || 0,
         durationMs: Date.now() - startTime,
         timestamp: Date.now(),
-        engine: 'gemini',
+        engine: engine || 'gemini',
         model: modelOverride || null,
         source: 'translate-doc-retry',
       },

--- a/test/unit/translate-doc-custom-cache-key.spec.js
+++ b/test/unit/translate-doc-custom-cache-key.spec.js
@@ -1,0 +1,52 @@
+// Unit test: custom-provider 文件翻譯 cache key 與 glossary helper 重構
+//
+// 為什麼有這條:
+//   1. v1.9.x 新增 TRANSLATE_DOC_BATCH_CUSTOM 後，文件翻譯會套用
+//      translateDoc.temperature 到 custom provider 路徑。
+//   2. 若 _oc_doc cache key 沒把 temperature 帶進去，使用者改文件翻譯溫度後會直接
+//      命中舊快取，看不到設定生效。
+//   3. 同次修改把 fixedGlossary + articleGlossary override 邏輯抽成 shared helper，
+//      避免 Gemini / custom provider 兩條 path 再次分叉。
+//
+// SANITY 紀錄(已驗證):
+//   - 移除 `_oc_doc` 的 `_t${cp.temperature.toFixed(2)}` 後，第 1 條會 fail。
+//   - 把 handleTranslate / handleTranslateCustom 改回各自內嵌 glossary merge 後，
+//     第 2 條會 fail。
+
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+
+function extractFunctionBody(src, startMarkerRe) {
+  const match = src.match(startMarkerRe);
+  if (!match) return null;
+  const startIdx = src.indexOf('{', match.index + match[0].length - 1);
+  if (startIdx === -1) return null;
+  let depth = 0;
+  for (let i = startIdx; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return src.slice(startIdx + 1, i);
+    }
+  }
+  return null;
+}
+
+test('background.js: handleTranslateCustom 對 _oc_doc cache key 納入 temperature', () => {
+  const src = fs.readFileSync('shinkansen/background.js', 'utf8');
+  const body = extractFunctionBody(src, /async\s+function\s+handleTranslateCustom\s*\(/);
+  expect(body, 'handleTranslateCustom 不存在或結構變了').toBeTruthy();
+  expect(body).toMatch(/cacheTag\s*===\s*['_"]_oc_doc['_"]\s*&&[\s\S]*cp\.temperature/);
+  expect(body).toMatch(/suffix\s*\+=\s*['_"]_t['_"]\s*\+\s*cp\.temperature\.toFixed\(2\)/);
+});
+
+test('background.js: Gemini / custom 兩條翻譯 path 共用 glossary helper', () => {
+  const src = fs.readFileSync('shinkansen/background.js', 'utf8');
+  expect(src).toMatch(/function\s+buildFixedGlossaryEntries\s*\(/);
+  expect(src).toMatch(/function\s+preferArticleGlossaryEntries\s*\(/);
+  expect(src).toMatch(/async\s+function\s+handleTranslate\s*\([\s\S]*?buildFixedGlossaryEntries\s*\(/);
+  expect(src).toMatch(/async\s+function\s+handleTranslate\s*\([\s\S]*?preferArticleGlossaryEntries\s*\(/);
+  expect(src).toMatch(/async\s+function\s+handleTranslateCustom\s*\([\s\S]*?buildFixedGlossaryEntries\s*\(/);
+  expect(src).toMatch(/async\s+function\s+handleTranslateCustom\s*\([\s\S]*?preferArticleGlossaryEntries\s*\(/);
+});

--- a/test/unit/translate-doc-engine-routing.spec.js
+++ b/test/unit/translate-doc-engine-routing.spec.js
@@ -1,0 +1,134 @@
+// Unit test: translate-doc engine routing
+//
+// 目標:
+//   1. 沒帶 engine / engine='gemini' 時，仍走既有 TRANSLATE_DOC_BATCH。
+//   2. engine='openai-compat' 時，才切到 TRANSLATE_DOC_BATCH_CUSTOM。
+//   3. LOG_USAGE 的 engine 欄位要跟實際 dispatch path 一致。
+//
+// 這條主要是保護「加 custom provider 後不要把 Gemini 文件翻譯路徑帶壞」。
+
+import { test, expect } from '@playwright/test';
+
+function makeDoc() {
+  return {
+    meta: { filename: 'sample.pdf' },
+    pages: [{
+      blocks: [{
+        blockId: 'b1',
+        type: 'paragraph',
+        plainText: 'Hello world',
+        linkUrls: [],
+      }],
+    }],
+  };
+}
+
+test.describe('translate-doc engine routing', () => {
+  test('translateDocument 預設仍走 Gemini handler', async () => {
+    const calls = [];
+    globalThis.chrome = {
+      runtime: {
+        sendMessage: async (msg) => {
+          calls.push(msg);
+          if (msg.type === 'TRANSLATE_DOC_BATCH') {
+            return {
+              result: ['你好世界'],
+              usage: { inputTokens: 10, outputTokens: 5, cacheHits: 0 },
+            };
+          }
+          if (msg.type === 'LOG_USAGE') return undefined;
+          throw new Error(`unexpected message: ${msg.type}`);
+        },
+      },
+    };
+
+    const { translateDocument } = await import(`../../shinkansen/translate-doc/translate.js?cb=${Date.now()}a`);
+    const summary = await translateDocument(makeDoc());
+
+    expect(summary.failedBlocks).toBe(0);
+    expect(calls[0].type).toBe('TRANSLATE_DOC_BATCH');
+    expect(calls[1].type).toBe('LOG_USAGE');
+    expect(calls[1].payload.engine).toBe('gemini');
+  });
+
+  test('translateDocument 在 openai-compat 時切 custom handler', async () => {
+    const calls = [];
+    globalThis.chrome = {
+      runtime: {
+        sendMessage: async (msg) => {
+          calls.push(msg);
+          if (msg.type === 'TRANSLATE_DOC_BATCH_CUSTOM') {
+            return {
+              result: ['你好世界'],
+              usage: { inputTokens: 10, outputTokens: 5, cacheHits: 0 },
+            };
+          }
+          if (msg.type === 'LOG_USAGE') return undefined;
+          throw new Error(`unexpected message: ${msg.type}`);
+        },
+      },
+    };
+
+    const { translateDocument } = await import(`../../shinkansen/translate-doc/translate.js?cb=${Date.now()}b`);
+    const summary = await translateDocument(makeDoc(), { engine: 'openai-compat' });
+
+    expect(summary.failedBlocks).toBe(0);
+    expect(calls[0].type).toBe('TRANSLATE_DOC_BATCH_CUSTOM');
+    expect(calls[1].type).toBe('LOG_USAGE');
+    expect(calls[1].payload.engine).toBe('openai-compat');
+  });
+
+  test('translateSingleBlock 預設仍走 Gemini handler', async () => {
+    const calls = [];
+    globalThis.chrome = {
+      runtime: {
+        sendMessage: async (msg) => {
+          calls.push(msg);
+          if (msg.type === 'TRANSLATE_DOC_BATCH') {
+            return {
+              result: ['你好世界'],
+              usage: { inputTokens: 3, outputTokens: 2, cacheHits: 0 },
+            };
+          }
+          if (msg.type === 'LOG_USAGE') return undefined;
+          throw new Error(`unexpected message: ${msg.type}`);
+        },
+      },
+    };
+
+    const { translateSingleBlock } = await import(`../../shinkansen/translate-doc/translate.js?cb=${Date.now()}c`);
+    const block = makeDoc().pages[0].blocks[0];
+    const result = await translateSingleBlock(block);
+
+    expect(result.ok).toBe(true);
+    expect(calls[0].type).toBe('TRANSLATE_DOC_BATCH');
+    expect(calls[1].payload.engine).toBe('gemini');
+  });
+
+  test('translateSingleBlock 在 openai-compat 時切 custom handler', async () => {
+    const calls = [];
+    globalThis.chrome = {
+      runtime: {
+        sendMessage: async (msg) => {
+          calls.push(msg);
+          if (msg.type === 'TRANSLATE_DOC_BATCH_CUSTOM') {
+            return {
+              result: ['你好世界'],
+              usage: { inputTokens: 3, outputTokens: 2, cacheHits: 0 },
+            };
+          }
+          if (msg.type === 'LOG_USAGE') return undefined;
+          throw new Error(`unexpected message: ${msg.type}`);
+        },
+      },
+    };
+
+    const { translateSingleBlock } = await import(`../../shinkansen/translate-doc/translate.js?cb=${Date.now()}d`);
+    const block = makeDoc().pages[0].blocks[0];
+    const result = await translateSingleBlock(block, { engine: 'openai-compat' });
+
+    expect(result.ok).toBe(true);
+    expect(calls[0].type).toBe('TRANSLATE_DOC_BATCH_CUSTOM');
+    expect(calls[1].payload.engine).toBe('openai-compat');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `TRANSLATE_DOC_BATCH_CUSTOM` handler for OpenAI-compatible providers (Ollama, llama.cpp, OpenRouter, etc.) in PDF translation
- Route by engine in `translate.js`: `openai-compat` → custom path, else Gemini (unchanged)
- `resolveModelOverride()` → `resolvePreset()` returning `{ engine, modelOverride }`
- Pass `engine` + `glossary` through reader.js retry path
- Extract `buildFixedGlossaryEntries` / `preferArticleGlossaryEntries` helpers (DRY `handleTranslate` + `handleTranslateCustom`)
- Add `_oc_doc` temperature cache key (align with Gemini `_doc` path)
- i18n: hint that Google Translate preset is not supported in doc translation

## Context

Previously, selecting a custom/local provider preset in translate-doc silently fell through to the Gemini API — either failing (wrong API key) or using the wrong model. This replicates the engine routing pattern already working in web page translation (`content.js`).

## Test plan

- [x] Unit tests pass (460 tests)
- [x] Manual: Gemini preset → translate PDF → works as before (regression check)
- [x] Manual: Custom provider preset (e.g. Ollama) → translate PDF → routes correctly
- [x] Manual: Retry failed blocks routes to correct engine