### PR TITLE
fix(youtube,ui): respect disabled subtitle auto-translate and declare light color-scheme

### DIFF
--- a/shinkansen/content-ns.js
+++ b/shinkansen/content-ns.js
@@ -374,6 +374,17 @@ if (window.__shinkansen_loaded) {
     return 'TRANSLATE_SUBTITLE_BATCH';
   };
 
+  // ASR 合句模式解析 — issue #58:engine='google' 強制 heuristic。
+  // 'llm' 的 JSON timestamp 翻譯與 'progressive' 的 LLM overlay(_runAsrWindow)都是
+  // LLM 任務,上方 getSubtitleBatchType 的 ASR 分支對 google 只能 fallback Gemini
+  // (Google MT 不支援 JSON 包裝,既定路由)→ 使用者選免費引擎仍靜默燒付費 API。
+  // 單點收斂在模式解析:google 一律 heuristic 合句(逐句翻,走
+  // TRANSLATE_SUBTITLE_BATCH_GOOGLE 免費端點),其餘引擎維持既有預設 progressive。
+  SK.resolveAsrMode = function resolveAsrMode(engine, asrMode) {
+    if (engine === 'google') return 'heuristic';
+    return asrMode || 'progressive';
+  };
+
   // 術語表抽取訊息類型路由 — 對齊字幕路由的單一資料源原則。
   // engine='openai-compat' 走 EXTRACT_GLOSSARY_CUSTOM(自訂 Provider chat.completions);
   // 其餘（含 google，因為術語表抽取是 LLM 任務，Google MT 不適用）走 EXTRACT_GLOSSARY(Gemini)。

--- a/shinkansen/content-youtube.js
+++ b/shinkansen/content-youtube.js
@@ -2435,7 +2435,9 @@
       //   - 'heuristic'   = F:啟發式合句 + 既有 TRANSLATE_SUBTITLE_BATCH(逐句翻)。延遲低、精度中。
       //   - 'llm'         = D':LLM 自由合句 + timestamp mode(_runAsrWindow)。延遲高、精度最高。
       //   - 'progressive' = E:先 heuristic 顯示(秒出),同時 fire-and-forget LLM 跑覆蓋。
-      const asrMode = config.asrMode || 'progressive';  // 預設 progressive(混合模式)
+      // issue #58:engine='google' 強制 heuristic(SK.resolveAsrMode,content-ns.js)——
+      // llm/progressive 的 LLM 路徑會忽略 google 設定 fallback Gemini 燒付費 API。
+      const asrMode = SK.resolveAsrMode(config.engine, config.asrMode);  // 預設 progressive(混合模式)
 
       // v1.9.22:seek / 緊急場景的 ASR 加速 — 算 wallLead(視窗起點距影片當前位置的
       // wall-clock ms,負數=video 已過視窗起點;這是 seek 進入此視窗的特徵)。
@@ -3732,13 +3734,18 @@
     SK.sendLog('info', 'youtube', 'SPA navigation reset', { wasActive, newVideoId: YT.videoId });
 
     // v1.3.1: SPA 導航後自動重啟字幕翻譯
-    // 條件：之前字幕翻譯已啟動（wasActive），或 ytSubtitle.autoTranslate 設定開啟
+    // 條件：ytSubtitle.autoTranslate 設定開啟；或未設定過但之前字幕翻譯已啟動（wasActive）
     // 若導航到非 watch 頁（例如首頁），略過。
     // 延遲 500ms 等 YouTube 播放器初始化並發出新字幕 XHR
     if (!SK.isYouTubePage?.()) return;
     try {
       const saved = await browser.storage.sync.get('ytSubtitle');
-      const shouldRestart = wasActive || saved.ytSubtitle?.autoTranslate;
+      // issue #58(CHANGELOG v1.4.21 記載的獨立 bug,至此才修):明確 false 優先於
+      // wasActive — 使用者關掉自動翻譯後,同分頁換影片不得因「剛才有在翻」而重啟。
+      // 未設定(undefined)沿用舊語意:wasActive 才重啟(手動啟動的跨影片延續)。
+      const shouldRestart = saved.ytSubtitle?.autoTranslate === false
+        ? false
+        : (wasActive || saved.ytSubtitle?.autoTranslate);
       if (shouldRestart) {
         SK.sendLog('info', 'youtube', 'SPA nav: will restart subtitle translation', {
           wasActive, autoTranslate: saved.ytSubtitle?.autoTranslate,

--- a/shinkansen/options/options.css
+++ b/shinkansen/options/options.css
@@ -1,3 +1,10 @@
+:root {
+  /* issue #57:本頁是純淺色設計。不宣告 color-scheme 時,macOS 深色模式下 WebKit
+     會給表單控制項套系統深色文字(近白)→ 疊在寫死的白底上 = 白字白底,輸入框
+     看起來是空的。明確聲明 light,控制項一律用淺色渲染。 */
+  color-scheme: light;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang TC', 'Microsoft JhengHei', sans-serif;
@@ -49,6 +56,7 @@ textarea {
   font: 13px -apple-system, 'PingFang TC', monospace;
   box-sizing: border-box;
   background: #fff;
+  color: #1d1d1f; /* issue #57:背景寫死就必須一起寫死前景,不依賴 UA 預設 */
 }
 
 textarea { resize: vertical; font-family: -apple-system, 'PingFang TC', sans-serif; }

--- a/shinkansen/popup/popup.css
+++ b/shinkansen/popup/popup.css
@@ -2,6 +2,9 @@
   /* 同 column 兄弟元件對齊基準寬（CLAUDE.md §1）——.display-mode-toggle + .row select
      共用同一寬，所有 locale 內 toggle 自然寬都 ≤ 此值（zh-TW 139px / en 132px 量過）。 */
   --popup-row-control-w: 140px;
+  /* issue #57:純淺色頁面,同 options.css — 不宣告時 macOS 深色模式下 WebKit
+     給表單控制項套近白文字,白底上看不見。 */
+  color-scheme: light;
 }
 
 body {
@@ -75,6 +78,7 @@ button.secondary:hover { background: #f0f4ff; }
   border-radius: 6px;
   font-size: 12px;
   background: #fff;
+  color: #1d1d1f; /* issue #57:背景寫死就必須一起寫死前景 */
   width: var(--popup-row-control-w);
 }
 

--- a/shinkansen/translate-doc/index.css
+++ b/shinkansen/translate-doc/index.css
@@ -2,6 +2,9 @@
  * 視覺基調對齊 options.css / popup.css（深灰白底、Apple 藍主色 #0071e3） */
 
 :root {
+  /* issue #57 同根因:純淺色頁 + 寫死白底,不宣告 color-scheme 時 macOS 深色模式
+     下 WebKit 給表單控制項套近白文字 → 白字白底。同 options.css / popup.css。 */
+  color-scheme: light;
   --bg: #ffffff;
   --bg-soft: #f7f7f8;
   --bg-zone: #fbfbfc;

--- a/test/regression/options-popup-color-scheme.spec.js
+++ b/test/regression/options-popup-color-scheme.spec.js
@@ -1,0 +1,61 @@
+// Regression:issue #57 — macOS 深色模式下 options 頁輸入框白字白底(值看起來是空的)
+//
+// 根因:options.css 表單控制項規則只寫死 background(#fff / transparent)卻沒設
+// color,且整頁零 color-scheme 宣告。macOS 系統深色模式下,WebKit 對未宣告
+// color-scheme 的頁面套用系統深色的表單控制項文字色(近白)→ 疊在白底上 =
+// 白字白底。三個症狀互證:placeholder 走 UA 獨立灰階所以看得到;選取反白時系統
+// 強制對比前景所以文字浮現;頁面一般文字有明確 color:#1d1d1f 所以正常。
+// popup.css 同款寫法(.row select 有 background 無 color)一併修。
+//
+// 驗到 / 沒驗到:
+//   ✅ :root 宣告 color-scheme: light(向引擎聲明本頁純淺色,表單控制項用淺色渲染)
+//   ✅ 表單控制項有明確前景色 rgb(29,29,31),不再依賴 UA 預設
+//   ❌ 真實 WebKit/macOS 深色模式的渲染結果 — Chromium 沒有 Safari 那種
+//      「系統外觀滲入未宣告 color-scheme 頁面」的行為,白字白底無法在本 harness
+//      重現;該層靠 Mac 實機(系統深色 + Safari 開設定頁)驗證。
+//
+// SANITY 紀錄(已驗證):把 options.css 的 :root color-scheme 與控制項 color 拿掉,
+// options 兩條斷言 fail(colorScheme='normal'、color=rgb(0,0,0));還原後全綠。
+import { test, expect } from '../fixtures/extension.js';
+
+const EXPECTED_TEXT_COLOR = 'rgb(29, 29, 31)'; // #1d1d1f,與頁面一般文字同色
+
+test('options 頁:root 宣告 color-scheme light + 表單控制項有明確前景色', async ({ context, extensionId }) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await page.waitForSelector('#apiKey');
+
+  const rootScheme = await page.evaluate(() => getComputedStyle(document.documentElement).colorScheme);
+  expect(rootScheme).toBe('light');
+
+  // 命中 options.css 表單控制項共用規則的兩類控制項(input[type=password] / select)。
+  // 術語表分頁的 input[type=text](.fg-source/.fg-target)走同一條規則,一併覆蓋。
+  const inputColor = await page.evaluate(() => getComputedStyle(document.querySelector('#apiKey')).color);
+  expect(inputColor).toBe(EXPECTED_TEXT_COLOR);
+  const selectColor = await page.evaluate(() => getComputedStyle(document.querySelector('#uiLanguage')).color);
+  expect(selectColor).toBe(EXPECTED_TEXT_COLOR);
+});
+
+test('popup 頁:root 宣告 color-scheme light + .row select 有明確前景色', async ({ context, extensionId }) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.waitForSelector('.row select');
+
+  const rootScheme = await page.evaluate(() => getComputedStyle(document.documentElement).colorScheme);
+  expect(rootScheme).toBe('light');
+
+  const selectColor = await page.evaluate(() => getComputedStyle(document.querySelector('.row select')).color);
+  expect(selectColor).toBe(EXPECTED_TEXT_COLOR);
+});
+
+// review 發現的同根因 sibling:translate-doc(文件翻譯)頁也是純淺色 + 寫死白底
+// + 零 color-scheme,Safari 深色模式下輸入框同樣白字白底。index.html 用 index.css;
+// settings.html 用 ../options/options.css(上方 options 修正已覆蓋,不需獨立斷言)。
+test('translate-doc 頁:root 宣告 color-scheme light', async ({ context, extensionId }) => {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/translate-doc/index.html`);
+  await page.waitForSelector('#app-main');
+
+  const rootScheme = await page.evaluate(() => getComputedStyle(document.documentElement).colorScheme);
+  expect(rootScheme).toBe('light');
+});

--- a/test/unit/subtitle-routing.spec.js
+++ b/test/unit/subtitle-routing.spec.js
@@ -70,3 +70,71 @@ test('content-ns.js SK.getSubtitleBatchType 內容跟 spec inline 邏輯一致',
 
   expect(nsBody).toBe(inlineBody);
 });
+
+// ─── issue #58:ASR 模式解析(engine='google' 強制 heuristic)──────────────
+//
+// 上游 issue #58 症狀 2:使用者把字幕引擎改成 google translate(免費)後,ASR 影片
+// 仍靜默呼叫預設 Gemini API 燒 tokens。根因:asrMode 預設 'progressive',其 LLM
+// overlay(_runAsrWindow)與 'llm' 模式的 JSON timestamp 翻譯都是 LLM 任務,
+// getSubtitleBatchType 的 ASR 分支對 google 只能 fallback Gemini(上方 case 表的
+// 文件化既定路由,不能動——Google MT 真的不支援 JSON timestamp 模式)。修法收斂在
+// 「模式解析」單點:engine='google' 時 ASR 一律走 heuristic 合句(逐句翻,走
+// TRANSLATE_SUBTITLE_BATCH_GOOGLE 免費端點),LLM 相關模式只在 LLM 引擎下生效。
+//
+// 驗到 / 沒驗到:
+//   ✅ SK.resolveAsrMode 決策表(google → heuristic;其餘引擎 passthrough + 預設 progressive)
+//   ✅ content-youtube.js 的 asrMode 取值點真的走 SK.resolveAsrMode(靜態鎖定,防 inline 回退)
+//   ❌ 「google + ASR 影片全程零付費 API 呼叫」的 e2e 層 — 需真實 YouTube 影片 + 網路,
+//      靠 Mac/桌面實測驗證。
+//
+// SANITY 紀錄(已驗證):把 content-ns.js helper 的 google 分支拿掉,
+// 「resolveAsrMode 同步」test fail;content-youtube.js 改回 inline
+// `config.asrMode || 'progressive'`,「取值走 SK.resolveAsrMode」test fail。
+
+// 重複 content-ns.js 的 SK.resolveAsrMode 邏輯,同上方 getSubtitleBatchType 的
+// inline + grep 比對模式。
+function resolveAsrMode(engine, asrMode) {
+  if (engine === 'google') return 'heuristic';
+  return asrMode || 'progressive';
+}
+
+const asrModeCases = [
+  // google:任何 asrMode 設定都強制 heuristic(免費引擎不得觸發 LLM 路徑)
+  { engine: 'google',        asrMode: 'progressive', expected: 'heuristic' },
+  { engine: 'google',        asrMode: 'llm',         expected: 'heuristic' },
+  { engine: 'google',        asrMode: 'heuristic',   expected: 'heuristic' },
+  { engine: 'google',        asrMode: undefined,     expected: 'heuristic' },
+  // LLM 引擎:passthrough
+  { engine: 'gemini',        asrMode: 'llm',         expected: 'llm' },
+  { engine: 'gemini',        asrMode: 'heuristic',   expected: 'heuristic' },
+  { engine: 'openai-compat', asrMode: 'progressive', expected: 'progressive' },
+  // 未設定 engine(預設 Gemini)/未設定 asrMode:維持既有預設 progressive
+  { engine: undefined,       asrMode: undefined,     expected: 'progressive' },
+  { engine: undefined,       asrMode: 'heuristic',   expected: 'heuristic' },
+];
+
+for (const c of asrModeCases) {
+  test(`resolveAsrMode(${String(c.engine)}, ${String(c.asrMode)}) → ${c.expected}`, () => {
+    expect(resolveAsrMode(c.engine, c.asrMode)).toBe(c.expected);
+  });
+}
+
+test('content-ns.js SK.resolveAsrMode 內容跟 spec inline 邏輯一致', () => {
+  const src = fs.readFileSync('shinkansen/content-ns.js', 'utf8');
+  const m = src.match(/SK\.resolveAsrMode\s*=\s*function\s+resolveAsrMode\s*\(engine,\s*asrMode\)\s*\{([\s\S]*?)\n  \};/);
+  expect(m, 'content-ns.js 找不到 SK.resolveAsrMode 定義').toBeTruthy();
+
+  const nsBody = m[1].replace(/\s+/g, ' ').trim();
+  const inlineSrc = resolveAsrMode.toString();
+  const inlineBody = inlineSrc.slice(inlineSrc.indexOf('{') + 1, inlineSrc.lastIndexOf('}'))
+    .replace(/\s+/g, ' ').trim();
+
+  expect(nsBody).toBe(inlineBody);
+});
+
+test('content-youtube.js 的 asrMode 取值走 SK.resolveAsrMode(不再 inline fallback)', () => {
+  const src = fs.readFileSync('shinkansen/content-youtube.js', 'utf8');
+  expect(src).toMatch(/const asrMode = SK\.resolveAsrMode\(\s*config\.engine\s*,\s*config\.asrMode\s*\)/);
+  // 舊 inline 寫法不得殘留(防止改回去繞過 google 強制)
+  expect(src).not.toMatch(/config\.asrMode \|\| 'progressive'/);
+});

--- a/test/unit/youtube-spa-nav-guard.spec.js
+++ b/test/unit/youtube-spa-nav-guard.spec.js
@@ -134,3 +134,104 @@ test.describe('content-youtube.js: yt-navigate-finish listener 同 videoId guard
     expect(body).toMatch(/['"]SPA nav skipped[^'"]*['"]/);
   });
 });
+
+// ─── issue #58:SPA 導航尊重「明確關閉的 autoTranslate」──────────────────
+//
+// CHANGELOG v1.4.21 已記載但當時未修的獨立 bug(上游 issue #58 症狀 1):重啟條件
+// `wasActive || autoTranslate` 讓 wasActive 短路掉使用者明確設為 false 的
+// ytSubtitle.autoTranslate — 只要本分頁字幕翻譯曾啟動過(安裝預設 true 的首次載入、
+// 或手動啟動),之後把設定關掉,同分頁換影片(SPA 導航)仍會繼續翻譯並燒 API。
+//
+// 修正語意:明確 false 一律不重啟;true 重啟;未設定(undefined)沿用舊行為
+// (wasActive 才重啟 — 手動啟動的跨影片延續)。
+//
+// 測法:extractListenerBody 抽出 handler body,AsyncFunction 注入 stub 依賴後直接
+// 呼叫,驗「translateYouTubeSubtitles 是否在 500ms 重啟排程後被呼叫」的行為層 —
+// 不是 static check,是真的執行 handler 原始碼。
+//
+// 驗到 / 沒驗到:
+//   ✅ 五種 (autoTranslate × wasActive) 組合的重啟決策(執行層)
+//   ❌ 真實 YouTube fire yt-navigate-finish 的時序 — 同上方 static check 區塊的限制
+//
+// SANITY 紀錄(已驗證):修正前(`wasActive || autoTranslate`)「false + wasActive=true
+// → 不重啟」case fail(實際重啟了);套上明確 false 優先後五條全綠。
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+function buildHandlerFromSource() {
+  const body = extractListenerBody(readFile('shinkansen/content-youtube.js'));
+  // body 是含外層 {} 的 block statement,直接當 function body 執行語意相同
+  return new AsyncFunction(
+    'SK', 'browser', 'getVideoIdFromUrl', 'stopYouTubeTranslation',
+    'hideCaptionStatus', '_debugRemove', '_setAsrHidingMode', '_removeOverlay',
+    'attachVideoListener',
+    body
+  );
+}
+
+function makeHarness({ active, ytSubtitle }) {
+  const startCalls = [];
+  const SK = {
+    YT: { active, videoId: 'video-OLD' },
+    isYouTubePage: () => true,
+    sendLog: () => {},
+    translateYouTubeSubtitles: (opts) => { startCalls.push(opts); return Promise.resolve(); },
+  };
+  const browser = {
+    storage: { sync: { get: async () => (ytSubtitle === undefined ? {} : { ytSubtitle }) } },
+  };
+  const handler = buildHandlerFromSource();
+  const invoke = () => handler(
+    SK, browser,
+    () => 'video-NEW',                       // getVideoIdFromUrl:模擬切到不同影片
+    () => { SK.YT.active = false; },         // stopYouTubeTranslation
+    () => {},                                // hideCaptionStatus
+    () => {},                                // _debugRemove
+    () => {},                                // _setAsrHidingMode
+    () => {},                                // _removeOverlay
+    () => {},                                // attachVideoListener
+  );
+  return { startCalls, invoke };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// handler 內部重啟走 setTimeout(500ms)。正負向都等固定 900ms:
+// 正向給排程足夠餘裕,負向依 create-env.cjs 慣例用固定等待驗「事情沒發生」。
+const RESTART_WAIT_MS = 900;
+
+test.describe('_onYtSpaNavigate 行為:autoTranslate 明確 false 不得重啟(issue #58)', () => {
+  test('autoTranslate=false + wasActive=true → 不重啟(本 issue 的核心 bug)', async () => {
+    const h = makeHarness({ active: true, ytSubtitle: { autoTranslate: false } });
+    await h.invoke();
+    await sleep(RESTART_WAIT_MS);
+    expect(h.startCalls.length).toBe(0);
+  });
+
+  test('autoTranslate=false + wasActive=false → 不重啟', async () => {
+    const h = makeHarness({ active: false, ytSubtitle: { autoTranslate: false } });
+    await h.invoke();
+    await sleep(RESTART_WAIT_MS);
+    expect(h.startCalls.length).toBe(0);
+  });
+
+  test('autoTranslate=true + wasActive=false → 重啟', async () => {
+    const h = makeHarness({ active: false, ytSubtitle: { autoTranslate: true } });
+    await h.invoke();
+    await sleep(RESTART_WAIT_MS);
+    expect(h.startCalls.length).toBe(1);
+  });
+
+  test('ytSubtitle 未設定 + wasActive=true → 重啟(手動啟動的跨影片延續)', async () => {
+    const h = makeHarness({ active: true, ytSubtitle: undefined });
+    await h.invoke();
+    await sleep(RESTART_WAIT_MS);
+    expect(h.startCalls.length).toBe(1);
+  });
+
+  test('ytSubtitle 未設定 + wasActive=false → 不重啟', async () => {
+    const h = makeHarness({ active: false, ytSubtitle: undefined });
+    await h.invoke();
+    await sleep(RESTART_WAIT_MS);
+    expect(h.startCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #58, Fixes #57

## 問題與根因

### #58 無法關閉 YouTube 字幕自動翻譯（兩個獨立 bug）

**1. SPA 換影片時 `wasActive` 蓋過已關閉的設定**
`content-youtube.js` 的 SPA 導航重啟條件是 `wasActive || ytSubtitle.autoTranslate`：只要本分頁字幕翻譯曾啟動過（安裝預設 true 的首次載入就會），之後把自動翻譯關掉，同分頁換影片仍會重啟。CHANGELOG v1.4.21 當時已記載此問題為「獨立 bug 另處理」，一直未處理。

修法：明確 `=== false` 一律不重啟；`true` 重啟；未設定（undefined）沿用舊語意（wasActive 才重啟，保留手動啟動的跨影片延續）。

**2. ASR 自動字幕在 google 引擎下仍靜默呼叫 Gemini 付費 API**
`asrMode` 預設 `progressive`，其 LLM overlay（`_runAsrWindow`）與 `llm` 模式都是 LLM 任務，`getSubtitleBatchType` 的 ASR 分支對 google 只能 fallback Gemini（Google MT 不支援 JSON timestamp 模式，該路由不能動）。結果是使用者選了免費引擎，只要影片是自動產生字幕就照燒 Gemini tokens，UI 無任何揭露——正是 issue 回報的「會使用到我的 tokens」。

修法：新增 `SK.resolveAsrMode(engine, asrMode)`（content-ns.js，單一決策點）：`engine==='google'` 強制 `heuristic` 合句，走免費 `TRANSLATE_SUBTITLE_BATCH_GOOGLE` 端點。已驗證 `config.asrMode` 全 repo 僅此一個讀取點、`_runAsrWindow` 僅有的兩個呼叫點都被 gate 住、Drive 字幕路徑不受影響（它本就把 google 路由到免費端點）。

### #57 Mac 版輸入框有值卻顯示空白

options 頁表單控制項只寫死 `background: #fff` 而未設 `color`，且整頁零 `color-scheme` 宣告。macOS 系統深色模式下，WebKit 對未宣告 color-scheme 的頁面套用系統深色控制項文字色（近白）→ 白字白底。三個症狀互證：placeholder 走 UA 獨立灰階所以可見；選取反白時系統強制對比色所以文字浮現（issue 截圖二的コルティナ）；一般文字有明確 `color:#1d1d1f` 所以正常。

修法：`options.css`、`popup.css`、`translate-doc/index.css`（review 發現的同根因第三頁；settings.html 共用 options.css 已一併覆蓋）宣告 `:root { color-scheme: light; }`，控制項補明確前景色。

## 測試

- 新增 8 條測試，全部先確認 RED 再修（核心 case：`autoTranslate=false + wasActive=true` 修前實際重啟，Expected 0 Received 1）：
  - `test/unit/youtube-spa-nav-guard.spec.js`：五種 (autoTranslate × wasActive) 組合的行為矩陣——抽出真實 handler body 以 AsyncFunction 執行，非 static check。
  - `test/unit/subtitle-routing.spec.js`：`resolveAsrMode` 決策表 + inline/grep 字面同步鎖（沿用檔內既有慣例）+ content-youtube.js 取值點靜態鎖定。
  - `test/regression/options-popup-color-scheme.spec.js`：三頁 computed `color-scheme` 與控制項前景色。
- SANITY 已驗證：逐一拔掉三個修正 → 正好只有對應測試 fail → 還原全綠。
- Full `npm test` 全綠（Playwright + Jest 241）。

## 尚需人工驗證的層次（spec 頭部已註明）

- 白字白底只在真實 WebKit + macOS 深色模式重現，Chromium harness 驗不到渲染層——需 Mac 實機（系統深色 + Safari 開設定頁）確認。
- 「google + ASR 影片全程零付費呼叫」的 e2e 層需真實 YouTube 影片實測。

版本號與 CHANGELOG 未動（version-check spec 強制 7 處同步，屬 release commit 範疇）。行為變更一點供斟酌：google 引擎下 ASR 合句模式 UI 勾選（progressive）會被靜默覆蓋為 heuristic——若希望在設定頁揭露此交互（例如 google 時 disable 該勾選並加 hint），我可以補一個 follow-up。