### PR TITLE
fix(ci): inject Instapaper consumer keys into release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,32 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
+      - name: Inject Instapaper consumer keys
+        # lib/instapaper-keys.js 是 gitignored（public repo 不 commit 金鑰），
+        # 所以乾淨 checkout 裡沒有這個檔 → 過去所有 release ZIP 都缺金鑰，
+        # 商店版使用者連結 Instapaper 一律吃「尚未設定 consumer 金鑰」（issue #61）。
+        # 這裡從 repo Secrets 產生金鑰檔，後面三個 ZIP（Chrome / Firefox / AMO source）
+        # 都會包到。檔案格式同本機模板：classic script 掛 globalThis.__SK
+        # （options/popup 路徑），且含 consumerKey: '…' 字面（service worker 的
+        # regex 路徑，見 background.js ensureInstapaperKeys）。
+        # Secrets 未設定 → 跳過並警告，行為同現狀（功能停用），不會弄壞 release。
+        env:
+          IP_KEY: ${{ secrets.INSTAPAPER_CONSUMER_KEY }}
+          IP_SECRET: ${{ secrets.INSTAPAPER_CONSUMER_SECRET }}
+        run: |
+          if [ -z "$IP_KEY" ] || [ -z "$IP_SECRET" ]; then
+            echo "::warning::INSTAPAPER_CONSUMER_KEY / INSTAPAPER_CONSUMER_SECRET secrets not set — Instapaper stays disabled in released builds (issue #61)"
+          elif [[ ! "$IP_KEY$IP_SECRET" =~ ^[0-9A-Za-z_-]+$ ]]; then
+            # 金鑰是 hex（見 background.js ensureInstapaperKeys 註解）。貼 secret 時誤帶
+            # 空白 / 換行 / 引號會產出 JS 語法壞掉的金鑰檔——比缺檔更難診斷的 silent
+            # failure（檔案存在但 classic script throw）。這裡改成 loud skip，行為退回
+            # 「功能停用」＝現狀。（[[ =~ ]] 對整串匹配；grep 是行導向會漏掉換行）
+            echo "::warning::Instapaper consumer key secrets contain unexpected characters (stray whitespace/quotes from copy-paste?) — skipping injection, Instapaper stays disabled"
+          else
+            printf "// Generated at release time from repo secrets (see release.yml). Do not commit.\nglobalThis.__SK = globalThis.__SK || {};\nglobalThis.__SK.INSTAPAPER_KEYS = { consumerKey: '%s', consumerSecret: '%s' };\n" "$IP_KEY" "$IP_SECRET" > shinkansen/lib/instapaper-keys.js
+            echo "Instapaper consumer keys injected"
+          fi
+
       - name: Zip shinkansen folder (Chrome)
         run: |
           zip -r shinkansen-${{ steps.version.outputs.VERSION }}.zip shinkansen/


### PR DESCRIPTION
Fixes #61

## 問題與根因

`lib/instapaper-keys.js` 被 gitignore(public repo 不 commit 金鑰的既定政策),但 `release.yml` 的流程是「乾淨 checkout → 直接 zip」,**沒有任何注入金鑰的步驟**——所以歷來所有公開發佈的 Chrome / Firefox ZIP 都不含金鑰檔。商店版使用者按「連結」時 `hasInstapaperConsumerKeys()` 必為 false,一律命中 `options.instapaper.errConfig`(「Instapaper 整合尚未設定 consumer 金鑰」),與 issue #61 的 Service Worker 截圖吻合。開發者本機因手動建過金鑰檔(gitignored)所以自測正常——典型 works-on-my-machine。

(Safari 版不受影響:`release.sh` 在本機跑 `safari-build.sh` 同步 Resources,本機有金鑰檔。這也解釋為何只有 Chrome / Firefox 使用者回報。)

## 修法

在 checkout 之後、三個 ZIP 步驟之前,新增「Inject Instapaper consumer keys」step:從 repo Secrets 產生 `shinkansen/lib/instapaper-keys.js`,Chrome / Firefox / AMO source 三個產物一致包含。檔案格式同本機模板,兩條讀取路徑都驗過:classic script 執行後掛 `globalThis.__SK`(options / popup 路徑),且含 `consumerKey: '…'` 字面讓 service worker 的 regex(`background.js` ensureInstapaperKeys)抓得到。

防禦分支(兩者都讓 release 照常完成,行為退回「功能停用」=現狀):

- **Secrets 未設定** → `::warning::` 並跳過。合併本 PR 而尚未設 secrets 完全無副作用。
- **金鑰格式異常**(貼 secret 時誤帶空白 / 換行 / 引號)→ `::warning::` 並跳過。若不擋,會產出 JS 語法壞掉的金鑰檔——比缺檔更難診斷的 silent failure(檔案存在但 classic script throw)。用 `[[ =~ ]]` 整串匹配而非 grep(grep 行導向,恰好漏掉最常見的「誤帶換行」)。

安全面:secrets 以 `env:` 綁定而非 `${{ }}` 內插進 script(無 template injection 面);產出走檔案 redirect,log 不印值;workflow 觸發僅 `push: tags: v*`(需 write 權限),fork PR 讀不到 secrets。

## ⚠️ 合併後需要的一次性設定(只有維護者能做)

Repo **Settings → Secrets and variables → Actions** 新增兩個 secret:

- `INSTAPAPER_CONSUMER_KEY`
- `INSTAPAPER_CONSUMER_SECRET`

(值 = 本機 `lib/instapaper-keys.js` 裡的兩個 hex 字串。)設定後的下一個 tag release,商店產物即含金鑰,商店使用者就能連結 Instapaper。

## 一個 trade-off 供斟酌

注入發生在 AMO source zip 打包之前,所以 consumer secret 也會進 source zip(給 AMO reviewer)。評估過沒有新增曝險:OAuth 1.0a consumer secret 在分發式 client app 本就隨每份下載的 extension 外流(任何人解開商店 ZIP 都看得到 `lib/instapaper-keys.js`),AMO source 提交只給 Mozilla reviewer、比商店產物更不公開;好處是 reviewer 重建產物與提交 ZIP 一致。若仍希望 source zip 乾淨,可把注入移到 source zip 之後(代價:reviewer 重建會差一個檔案),我可以補 follow-up。

## 測試

- YAML 結構驗證(js-yaml parse,7 steps 順序正確:注入在三個 zip 之前)。
- 注入 script 本機 smoke test:產出檔案同時通過 classic script 執行(`globalThis.__SK.INSTAPAPER_KEYS` 值正確)與 SW regex 抽取兩條路徑。
- guard 字元集逐 case 驗證:hex 通過;trailing / middle newline、空白、單引號、反斜線全數攔下。
- workflow 無法在 fork 端到端試跑(tag push 觸發 + secrets 只在 upstream repo),上述為可驗證的全部層次。
