### PR TITLE
fix(custom-provider): 非 JSON 的 HTTP 200 回應不再誤判為連線成功

### DIFF
--- a/shinkansen/background.js
+++ b/shinkansen/background.js
@@ -2055,7 +2055,16 @@ async function testCustomProvider(payload) {
       body: JSON.stringify(reqBody),
     }, 10000);
     if (resp.ok) {
-      const j = await resp.json().catch(() => ({}));
+      let j;
+      try {
+        j = await resp.json();
+      } catch {
+        return {
+          ok: false,
+          status: resp.status,
+          message: `HTTP ${resp.status}，但 Provider 回應不是有效的 JSON。請確認 Base URL 是否為正確的 OpenAI-compatible API endpoint。`,
+        };
+      }
       const used = j?.usage?.total_tokens || j?.usage?.prompt_tokens || 0;
       const modelLabel = model || j?.model || 'server-default';
       return { ok: true, status: resp.status, message: `連線成功（${modelLabel}，本次用量約 ${used} tokens）` };


### PR DESCRIPTION
## 問題說明

自訂 Provider 測試目前只檢查 HTTP status。錯誤 Base URL 可能被 SPA fallback 回傳 `HTTP 200 + text/html`，測試因此誤判連線成功，但正式翻譯時才失敗。

## 重現方式

1. 在自訂 Provider 設定錯誤的 Base URL，指向會回傳 SPA fallback 頁面的網址。
2. 點擊「測試」按鈕。
3. Provider 回傳 HTTP 200 與 HTML 內容，但測試顯示連線成功。
4. 執行正式翻譯，請求因回應不是預期 JSON 而失敗。

## 原因

`testCustomProvider()` 使用 `resp.json().catch(() => ({}))` 吞掉 JSON 解析錯誤。只要 HTTP status 為 2xx，就會繼續回傳 `ok: true`。

## 修正方式

HTTP 2xx 回應改在 `try/catch` 中解析 JSON；解析失敗時回傳 `ok: false`、HTTP status 與明確錯誤訊息，避免非 JSON 成功回應形成 false positive。

## 預期行為

- HTTP 2xx 且 body 為有效 JSON：測試成功。
- HTTP 2xx 但 body 非有效 JSON：測試失敗，提示確認 Base URL 是否為正確的 OpenAI-compatible API endpoint。
- 非 2xx 回應：維持既有錯誤處理行為。